### PR TITLE
Add NetworkManager to CoreModule for handling API requests

### DIFF
--- a/Modules/CoreModule/Sources/CoreModule/Extensions/Encodable.swift
+++ b/Modules/CoreModule/Sources/CoreModule/Extensions/Encodable.swift
@@ -1,0 +1,21 @@
+//
+//  Encodable.swift
+//  CoreModule
+//
+//  Created by Mohammed Essam on 19/03/2025.
+//
+
+import Foundation
+
+// MARK: - asDictionary convert any Codable model to dictionary
+//
+public extension Encodable {
+    var asDictionary: [String: Any] {
+        let serialized = (try? JSONSerialization.jsonObject(with: encoded, options: .allowFragments))
+        return ((serialized as? [String: Any]) ?? [:]).compactMapValues { $0 }
+    }
+    
+    private var encoded: Data {
+        return (try? JSONEncoder().encode(self)) ?? Data()
+    }
+}

--- a/Modules/CoreModule/Sources/CoreModule/Network/Domain/Entities/CommonHeader.swift
+++ b/Modules/CoreModule/Sources/CoreModule/Network/Domain/Entities/CommonHeader.swift
@@ -1,0 +1,19 @@
+//
+//  CommonHeader.swift
+//  CoreModule
+//
+//  Created by Mohammed Essam on 19/03/2025.
+//
+
+import Foundation
+
+//MARK: - CommonHeader
+public struct CommonHeader: Codable {
+    var accept: String = "application/json"
+    var content: String = "application/json"
+    
+    enum CodingKeys: String, CodingKey {
+        case accept = "Accept"
+        case content = "Content-Type"
+    }
+}

--- a/Modules/CoreModule/Sources/CoreModule/Network/Domain/Entities/NetworkError.swift
+++ b/Modules/CoreModule/Sources/CoreModule/Network/Domain/Entities/NetworkError.swift
@@ -1,0 +1,24 @@
+//
+//  NetworkError.swift
+//  CoreModule
+//
+//  Created by Mohammed Essam on 19/03/2025.
+//
+
+import Foundation
+
+// MARK: - NetworkError
+//
+public enum NetworkError: Error {
+    case notData
+    case other(code: Int? = nil, msg:String)
+    
+    var localizedDescription: String {
+        switch self {
+        case .other(_, let msg):
+            return msg
+        case .notData:
+            return "No Data Found"
+        }
+    }
+}

--- a/Modules/CoreModule/Sources/CoreModule/Network/Domain/Entities/RequestMethod.swift
+++ b/Modules/CoreModule/Sources/CoreModule/Network/Domain/Entities/RequestMethod.swift
@@ -1,0 +1,18 @@
+//
+//  RequestMethod.swift
+//  CoreModule
+//
+//  Created by Mohammed Essam on 19/03/2025.
+//
+
+import Foundation
+
+// MARK: - RequestMethod
+//
+public enum RequestMethod: String {
+  case delete = "DELETE"
+  case get = "GET"
+  case patch = "PATCH"
+  case post = "POST"
+  case put = "PUT"
+}

--- a/Modules/CoreModule/Sources/CoreModule/Network/Presentation/NetworkManager.swift
+++ b/Modules/CoreModule/Sources/CoreModule/Network/Presentation/NetworkManager.swift
@@ -1,0 +1,63 @@
+//
+//  NetworkManager.swift
+//  CoreModule
+//
+//  Created by Mohammed Essam on 19/03/2025.
+//
+
+import Foundation
+
+// MARK: - Network Manager
+//
+public actor NetworkManager {
+    lazy private var session: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.requestCachePolicy = .returnCacheDataElseLoad
+        config.urlCache = URLCache(memoryCapacity: 50_000_000, diskCapacity: 100_000_000, diskPath: nil)
+        return URLSession(configuration: config)
+    }()
+
+    public init() {}
+}
+
+// MARK: - Request
+//
+public extension NetworkManager {
+    func request<T: Codable>(_ request: URLRequest) async throws -> T {
+#if DEBUG
+        print("--------------------------------------------------------\n",
+              "URL:            \(request.url?.absoluteString ?? "")\n",
+              "data:           \((try? JSONSerialization.jsonObject(with: request.httpBody ?? Data(), options: []) as? [String: Any]) ?? [:])\n",
+              "--------------------------------------------------------")
+#endif
+        
+        let (data, response) = try await session.data(for: request)
+        try response.checkValidation(with: data)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}
+
+// MARK: - Validation
+//
+private extension URLResponse {
+    func checkValidation(with data: Data) throws {
+#if DEBUG
+        print("--------------------------------------------------------\n",
+              "URL:            \(url?.absoluteString ?? "")\n",
+              "statusCode:     \((self as? HTTPURLResponse)?.statusCode ?? 0)\n",
+              "data:           \((try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]) ?? [:])\n",
+              "--------------------------------------------------------")
+#endif
+        
+        guard let httpResponse = self as? HTTPURLResponse else {
+            throw NetworkError.notData
+        }
+        
+        guard ((200...299).contains(httpResponse.statusCode)) else {
+            throw NetworkError.other(
+                code: httpResponse.statusCode,
+                msg: "Seems like something went wrong"
+            )
+        }
+    }
+}

--- a/Modules/CoreModule/Sources/CoreModule/Network/Presentation/NetworkRequestBuilder.swift
+++ b/Modules/CoreModule/Sources/CoreModule/Network/Presentation/NetworkRequestBuilder.swift
@@ -1,0 +1,71 @@
+//
+//  NetworkRequestBuilder.swift
+//  CoreModule
+//
+//  Created by Mohammed Essam on 19/03/2025.
+//
+
+import Foundation
+
+public class NetworkRequestBuilder {
+    private var request: URLRequest
+    
+    public init(baseURL: String) {
+        request = URLRequest(url: URL(string: baseURL)!)
+        _ = setMethod(.get)
+        _ = setHeaders(CommonHeader().asDictionary as? [String: String] ?? [:])
+    }
+}
+
+public extension NetworkRequestBuilder {
+    @discardableResult
+    func setPath(_ path: String) -> Self {
+        guard let baseURL = request.url else { return self }
+        let path = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+        request.url = baseURL.appendingPathComponent(path)
+        return self
+    }
+    
+    @discardableResult
+    func setMethod(_ method: String) -> Self {
+        request.httpMethod = method
+        return self
+    }
+    @discardableResult
+    func setMethod(_ method: RequestMethod) -> Self {
+        request.httpMethod = method.rawValue
+        return self
+    }
+    
+    @discardableResult
+    func setHeaders(_ headers: [String: String]) -> Self {
+        for (key, value) in headers {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        return self
+    }
+    
+    @discardableResult
+    func setBody(_ body: Data?) -> Self {
+        request.httpBody = body
+        return self
+    }
+    @discardableResult
+    func setBody(_ body: [String: Any]) -> Self {
+        request.httpBody =  try? JSONSerialization.data(withJSONObject: body, options: [.prettyPrinted])
+        return self
+    }
+    
+    @discardableResult
+    func setQuery(_ parameters: [String: String]) -> Self {
+        guard let url = request.url else { return self }
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        components?.queryItems = parameters.map { URLQueryItem(name: $0.key, value: $0.value) }
+        request.url = components?.url
+        return self
+    }
+    
+    func build() -> URLRequest {
+        return request
+    }
+}


### PR DESCRIPTION
#### **Summary**  
This PR introduces `NetworkManager`, an `actor`-based network layer to handle API requests in the `CoreModule`. The implementation leverages Swift Concurrency (`async/await`) and includes response validation, caching, and error handling.  

#### **Key Changes**  
✅ Added `NetworkManager` with `request<T: Codable>(_:)` to perform network calls.  
✅ Implemented `URLResponse` validation to ensure only successful responses (HTTP 200-299) are processed.  
✅ Configured `URLSession` with caching support for improved performance.  
✅ Added debug logs to print request details in `DEBUG` mode for easier debugging.  

#### **Implementation Details**  
- Uses `URLSessionConfiguration` with caching enabled (`returnCacheDataElseLoad`).  
- Throws `NetworkError` for invalid responses or decoding failures.  
- Logs request and response data when running in `DEBUG` mode.  

#### **How to Use**  
```swift
let request = URLRequest(url: URL(string: "https://restcountries.com/v2/all")!)
do {
    let countries: [Country] = try await NetworkManager().request(request)
    print("Countries: \(countries)")
} catch {
    print("Request failed: \(error)")
}
```

#### **Next Steps**  
- Add unit tests for various network scenarios.  
- Enhance error handling with more descriptive messages.  
- Optimize caching policies for different request types.  
