### PR TITLE
Add NetworkActivityIndicator for tracking network requests

### DIFF
--- a/Modules/CoreModule/Sources/CoreModule/ActivityIndicator/ActivityIndicator.swift
+++ b/Modules/CoreModule/Sources/CoreModule/ActivityIndicator/ActivityIndicator.swift
@@ -1,0 +1,33 @@
+//
+//  ActivityIndicator.swift
+//  CoreModule
+//
+//  Created by Mohammed Essam on 19/03/2025.
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor public final class NetworkActivityIndicator: ObservableObject {
+    private var counter: Int = 0
+    @Published public var isLoading: Bool = false
+    
+    public static let shared = NetworkActivityIndicator()
+    private init() {}
+}
+
+public extension NetworkActivityIndicator {
+    func startLoading() {
+        counter += 1
+        updatePublisher()
+    }
+    
+    func stopLoading() {
+        counter -= 1
+        updatePublisher()
+    }
+    
+    private func updatePublisher() {
+        isLoading = (counter != 0)
+    }
+}


### PR DESCRIPTION
### Summary  
This PR introduces `NetworkActivityIndicator`, a singleton class designed to track ongoing network requests and update a published `isLoading` state accordingly. It ensures a consistent way to manage network activity indicators across the app.  

### Changes Introduced  
- Added `NetworkActivityIndicator` as a `@MainActor final class`.  
- Implements a counter-based mechanism to track active network requests.  
- Provides `startLoading()` and `stopLoading()` methods to update `isLoading`.  
- Ensures thread safety using `@MainActor`.  
- Can be used in the `VMContract` to manage loading states during API calls.  

### Why This Change?  
- Centralized network activity tracking.  
- Avoids UI inconsistencies where multiple requests might incorrectly toggle loading states.  
- Improves user experience by providing accurate loading indicators.  

### How to Test?  
1. Trigger multiple API calls and observe `isLoading`.  
2. Ensure it turns `true` when requests start and `false` when all requests complete.  

### Notes  
This should be integrated into the ViewModel layer to manage network activity indicators effectively.  
